### PR TITLE
表格显示不全，修改Bscroll配置

### DIFF
--- a/src/components/core/d2-container/index.vue
+++ b/src/components/core/d2-container/index.vue
@@ -77,7 +77,7 @@ export default {
   methods: {
     scrollInit () {
       this.BS = new BScroll(this.$refs.container, {
-        mouseWheel: true,
+        wheel: true,
         scrollbar: {
           fade: true,
           interactive: false


### PR DESCRIPTION
百万数据表格显示不全，没办法滚动。
修改了一下Bscroll的配置