### PR TITLE
【BUG】IE 显示异常的问题

### DIFF
--- a/src/assets/style/theme/theme-base.scss
+++ b/src/assets/style/theme/theme-base.scss
@@ -63,7 +63,7 @@
         }
         .d2-theme-container-main-body {
           flex-grow: 1;
-          margin-top: 1px;
+          // margin-top: 1px;
           position: relative;
         }
       }
@@ -218,6 +218,7 @@
         // 主体部分分为多页面控制器 和主体
         .d2-theme-container-main-header {
           // 多页面控制器
+          overflow: hidden;
           .d2-multiple-page-control-group {
             display: flex;
             margin-right: 20px;
@@ -225,9 +226,9 @@
               flex-grow: 1;
               position: relative;
               .d2-multiple-page-control-content-inner {
-                position: absolute;
-                left: 0px;
-                right: 0px;
+                // position: absolute;
+                // left: 0px;
+                // right: 0px;
                 .d2-multiple-page-control {
                   .el-tabs__header.is-top {
                     margin: 0px;


### PR DESCRIPTION
解决方案 —— .d2-theme-container-main-header 增加overflow
产生原因 —— display:inline-block + font-size
衍生bug —— 样式显示边框有异常
【BUG】边框缝隙没有密合：
解决方案 —— .d2-multiple-page-control-content-inner 去掉绝对定位，.d2-theme-container-main-body 去掉 margin-top
产生原因 —— 绝对定位导致父容器包含的区域小于子容器，而用了margin-top显然是为了解决父容器少掉的1px，但也造成了盒模型的渲染不一致
衍生bug —— 暂无