### PR TITLE
【BUG】修复IE情况的显示异常

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "vue-router": "^3.0.1",
     "vue-splitpane": "^1.0.2",
     "vuex": "^3.0.1",
-    "xlsx": "^0.12.0"
+    "xlsx": "^0.12.0",
+    "flex.css": "^1.1.7"
   },
   "devDependencies": {
     "@kazupon/vue-i18n-loader": "^0.3.0",

--- a/src/assets/style/theme/theme-base.scss
+++ b/src/assets/style/theme/theme-base.scss
@@ -28,23 +28,11 @@
     @extend %full;
     $d2-theme-header-height: 60px;
     .d2-theme-header {
-      position: absolute;
-      top: 0px;
-      left: 0px;
-      right: 0px;
       height: $d2-theme-header-height;
     }
     .d2-theme-container {
-      position: absolute;
-      top: $d2-theme-header-height;
-      bottom: 0px;
-      left: 0px;
-      right: 0px;
-      display: flex;
-      flex-direction: row;
       .d2-theme-container-aside {
         transition: width .3s;
-        flex-grow: 0;
         position: relative;
         .d2-layout-header-aside-menu-side {
           @extend %full;
@@ -52,18 +40,10 @@
         }
       }
       .d2-theme-container-main {
-        flex-grow: 1;
         padding: 0px;
         position: relative;
         overflow: hidden;
-        display: flex;
-        flex-direction: column;
-        .d2-theme-container-main-header {
-          flex-grow: 0;
-        }
         .d2-theme-container-main-body {
-          flex-grow: 1;
-          // margin-top: 1px;
           position: relative;
         }
       }
@@ -192,10 +172,6 @@
           margin: 10px;
           margin-top: 0px;
           border-radius: 4px;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          flex-direction: column;
           @extend %unable-select;
           i {
             font-size: 30px;
@@ -220,15 +196,11 @@
           // 多页面控制器
           overflow: hidden;
           .d2-multiple-page-control-group {
-            display: flex;
-            margin-right: 20px;
+            padding-right: 20px;
             .d2-multiple-page-control-content {
-              flex-grow: 1;
+              overflow: auto;
               position: relative;
               .d2-multiple-page-control-content-inner {
-                // position: absolute;
-                // left: 0px;
-                // right: 0px;
                 .d2-multiple-page-control {
                   .el-tabs__header.is-top {
                     margin: 0px;

--- a/src/layout/header-aside/components/menu-side/index.vue
+++ b/src/layout/header-aside/components/menu-side/index.vue
@@ -11,7 +11,7 @@
         <d2-layout-header-aside-menu-sub v-else :menu="menu" :key="menuIndex"/>
       </template>
     </el-menu>
-    <div v-if="menuAside.length === 0 && !isMenuAsideCollapse" class="d2-layout-header-aside-menu-empty">
+    <div v-if="menuAside.length === 0 && !isMenuAsideCollapse" class="d2-layout-header-aside-menu-empty" flex="dir:top main:center cross:center">
       <d2-icon name="inbox"/>
       <span>没有侧栏菜单</span>
     </div>

--- a/src/layout/header-aside/components/tabs/index.vue
+++ b/src/layout/header-aside/components/tabs/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="d2-multiple-page-control-group">
-    <div class="d2-multiple-page-control-content">
+  <div class="d2-multiple-page-control-group" flex>
+    <div class="d2-multiple-page-control-content" flex-box="1">
       <div class="d2-multiple-page-control-content-inner">
         <el-tabs
           class="d2-multiple-page-control"
@@ -18,7 +18,7 @@
         </el-tabs>
       </div>
     </div>
-    <div class="d2-multiple-page-control-btn">
+    <div class="d2-multiple-page-control-btn" flex-box="0">
       <el-dropdown
         split-button
         @click="handleControlBtnClick"

--- a/src/layout/header-aside/layout.vue
+++ b/src/layout/header-aside/layout.vue
@@ -6,9 +6,9 @@
     <!-- 半透明遮罩 -->
     <div class="d2-layout-header-aside-mask"></div>
     <!-- 主体内容 -->
-    <div class="d2-layout-header-aside-content">
+    <div class="d2-layout-header-aside-content" flex="dir:top">
       <!-- 顶栏 -->
-      <div class="d2-theme-header">
+      <div class="d2-theme-header" flex-box="0">
         <div class="logo-group" :style="{width: isMenuAsideCollapse ? asideWidthCollapse : asideWidth}">
           <img v-if="isMenuAsideCollapse" :src="`${$baseUrl}image/theme/${d2adminThemeActiveSetting.name}/logo/icon-only.png`">
           <img v-else :src="`${$baseUrl}image/theme/${d2adminThemeActiveSetting.name}/logo/all.png`">
@@ -26,20 +26,21 @@
         </div>
       </div>
       <!-- 下面 主体 -->
-      <div class="d2-theme-container">
+      <div class="d2-theme-container" flex-box="1" flex>
         <!-- 主体 侧边栏 -->
         <div
+          flex-box="0"
           ref="aside"
           class="d2-theme-container-aside"
           :style="{width: isMenuAsideCollapse ? asideWidthCollapse : asideWidth}">
           <d2-menu-side/>
         </div>
         <!-- 主体 -->
-        <div class="d2-theme-container-main">
-          <div class="d2-theme-container-main-header">
+        <div class="d2-theme-container-main" flex-box="1" flex="dir:top">
+          <div class="d2-theme-container-main-header" flex-box="0">
             <d2-tabs/>
           </div>
-          <div class="d2-theme-container-main-body">
+          <div class="d2-theme-container-main-body" flex-box="1">
             <transition name="fade-transverse">
               <keep-alive :include="d2adminKeepAliveInclude">
                 <router-view/>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import 'babel-polyfill'
 import Vue from 'vue'
 import App from './App'
+// flex.css
+import 'flex.css'
 import ElementUI from 'element-ui'
 import 'element-ui/lib/theme-chalk/index.css'
 import VCharts from 'v-charts'


### PR DESCRIPTION
昨天衍生出来的bug：flex下的margin-right导致的。
在昨天的基础上：
1. 引入了flex.css，这个工具可以在实际开发中继续方便快速构建业务页面 —— 可以加一个页面说明
2. 将布局的部分从样式中脱离出来，在html里一目了然。
3. 测试情况：
测试环境：Chrome，IE11，Edge
—— 显示正常
—— 边框没有1px的问题
—— 标签过多显示正常