### PR TITLE
矢量icon颜色与链接文字颜色同步

### DIFF
--- a/src/assets/style/theme/theme.scss
+++ b/src/assets/style/theme/theme.scss
@@ -188,6 +188,7 @@
           }
           &:hover {
             color: $theme-aside-item-color-hover;
+            fill: $theme-aside-item-color-hover;
             background: $theme-aside-item-background-color-hover;
             i {
               color: $theme-aside-item-color-hover;
@@ -195,6 +196,7 @@
           }
           &:focus {
             color: $theme-aside-item-color-focus;
+            fill: $theme-aside-item-color-focus;
             background: $theme-aside-item-background-color-focus;
             i {
               color: $theme-aside-item-color-focus;
@@ -202,6 +204,7 @@
           }
           &.is-active {
             color: $theme-aside-item-color-active;
+            fill: $theme-aside-item-color-active;
             background: $theme-aside-item-background-color-active;
             i {
               color: $theme-aside-item-color-active;


### PR DESCRIPTION
矢量icon颜色与链接文字颜色同步，利用fill样式，svg矢量图标文件中不能有内部样式，否则无效