### PR TITLE
fix: 调用next(...)重定向不会触发router.afterEach事件

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,7 @@ router.beforeEach((to, from, next) => {
           redirect: to.fullPath
         }
       })
+      NProgress.done() // hack
     }
   } else {
     // 不需要身份校验 直接通过


### PR DESCRIPTION
如果在未登录状态下，在地址栏输入需要登录后才能访问的页面，应用会重定向至login，但是这时顶部的NProgress依然在加载中。这里需要手动hack一下。