### PR TITLE
菜单栏增加单页面刷新功能

### DIFF
--- a/src/layout/header-aside/components/tabs/index.vue
+++ b/src/layout/header-aside/components/tabs/index.vue
@@ -27,6 +27,9 @@
       </div>
     </div>
     <div class="d2-multiple-page-control-btn" flex-box="0">
+      <el-button  @click="handleRefresh">
+        <d2-icon name="refresh"/>
+      </el-button>
       <el-dropdown
         size="default"
         split-button
@@ -97,6 +100,14 @@ export default {
       'closeAll',
       'openedSort'
     ]),
+    /**
+     * @description 仅刷新当前router组件 不影响其他已缓存的组件
+     */
+    handleRefresh () {
+      this.$router.push({
+        name: 'refresh'
+      })
+    },
     /**
      * @description 计算某个标签页是否可关闭
      * @param {Object} page 其中一个标签页

--- a/src/layout/header-aside/layout.vue
+++ b/src/layout/header-aside/layout.vue
@@ -63,7 +63,7 @@
               <div class="d2-theme-container-main-body" flex-box="1">
                 <transition :name="transitionActive ? 'fade-transverse' : ''">
                   <keep-alive :include="keepAlive">
-                    <router-view/>
+                    <router-view :key="$route.path + $route.meta[$route.path]" />
                   </keep-alive>
                 </transition>
               </div>

--- a/src/views/demo/playground/page-cache/params.vue
+++ b/src/views/demo/playground/page-cache/params.vue
@@ -39,37 +39,7 @@ export default {
   },
   data () {
     return {
-      datas: [],
       data: { value: '' }
-    }
-  },
-  methods: {
-    switchData (id) {
-      let data = this.datas[id]
-      if (!data) {
-        data = { value: '' }
-        this.datas[id] = data
-      }
-      this.data = data
-    }
-  },
-  // 第一次进入或从其他组件对应路由进入时触发
-  beforeRouteEnter (to, from, next) {
-    const id = to.params.id
-    if (id) {
-      next(instance => instance.switchData(id))
-    } else {
-      next(new Error('未指定ID'))
-    }
-  },
-  // 在同一组件对应的多个路由间切换时触发
-  beforeRouteUpdate (to, from, next) {
-    const id = to.params.id
-    if (id) {
-      this.switchData(id)
-      next()
-    } else {
-      next(new Error('未指定ID'))
     }
   }
 }

--- a/src/views/system/function/refresh/index.js
+++ b/src/views/system/function/refresh/index.js
@@ -1,6 +1,7 @@
 export default {
   beforeRouteEnter (to, from, next) {
-    next(instance => instance.$router.replace(from.fullPath))
+    from.meta[from.path] = Date.now()
+    next(instance => instance.$router.replace({ path: from.fullPath, meta: from.meta }))
   },
   render: h => h()
 }


### PR DESCRIPTION
1.移除带参路由来回切换data的操作
2.只刷新当前router，不影响其他已缓存的router