### PR TITLE
fix: 🐛 注销用户清空vuex用户信息失效

### DIFF
--- a/src/store/modules/d2admin/modules/account.js
+++ b/src/store/modules/d2admin/modules/account.js
@@ -42,9 +42,9 @@ export default {
       async function logout () {
         // 删除cookie
         util.cookies.remove('token')
-        util.cookies.remove('uuid')
         // 清空 vuex 用户信息
         await dispatch('d2admin/user/set', {}, { root: true })
+        util.cookies.remove('uuid')
         // 跳转路由
         router.push({ name: 'login' })
       }


### PR DESCRIPTION
注销用户清空vuex用户信息，需要在uuid删除之前，不然无法删除